### PR TITLE
Adding express-request-proxy, and using it to handle the new way for …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 js/models/gitToken.js
+env.sh

--- a/index.html
+++ b/index.html
@@ -75,7 +75,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.0.4/handlebars.js"></script>
     <script src="/lib/scripts/page.js"></script>
 
-    <script type="text/javascript" src="/js/models/gitToken.js"></script>
     <script type="text/javascript" src="/js/models/project.js"></script>
     <script type="text/javascript" src="/js/views/sectionView.js"></script>
     <script type="text/javascript" src="/js/controllers/projectController.js"></script>

--- a/js/models/project.js
+++ b/js/models/project.js
@@ -88,24 +88,18 @@
 
   //Method that call upon the github /repos endpoint to get all the repositories sorted by last updated from my github account filtered by non fork repos.
   Project.requestRepos = function(callback){
-    $.ajax({
-      url: 'https://api.github.com/users/' + gitRepo.gitUser + '/repos' + '?sort=updated',
-      type: 'GET',
-      headers: {'Authorization': 'token ' + gitRepo.gitToken},
-      success: function(data, message, xhr){
-        console.log(data);
-        reposArray = data.filter(function(repo){
-          return repo.fork === false;
-        }).map(function(repo){
-          return {
-            name: repo.name,
-            updated_at: repo.updated_at,
-            html_url: repo.html_url
-          };
-        });
-        callback();
-      }
-    });
+    $.get('/github/users/mmailman/repos' + '?sort=updated')
+    .done(function(data){
+      reposArray = data.filter(function(repo){
+        return repo.fork === false;
+      }).map(function(repo){
+        return {
+          name: repo.name,
+          updated_at: repo.updated_at,
+          html_url: repo.html_url
+        };
+      });
+    }).done(callback);
   };
 
   //Method to mutate the data in the Project.all property with updated information from the github /repos api

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "homepage": "https://github.com/mmailman/portfolio#readme",
   "dependencies": {
-    "express": "^4.13.4"
+    "express": "^4.13.4",
+    "express-request-proxy": "^2.0.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,6 +1,17 @@
 var express = require('express'),
   app = express(),
   port = process.env.PORT || 3000;
+var requestProxy = require('express-request-proxy');
+
+var proxyGitHub = function(request, response) {
+  console.log('Routing GitHub request for', request.params[0]);
+  (requestProxy({
+    url: 'https://api.github.com/' + request.params[0],
+    headers: { Authorization: 'token ' + process.env.GITHUB_TOKEN }
+  }))(request, response);
+};
+
+app.get('/github/*', proxyGitHub);
 
 app.use(express.static('./'));
 


### PR DESCRIPTION
…the GITHUB_TOKEN, refactored the ajax call the the api to use this new way.in preparation for a heroku deployment.

This took about an hour, ran into a weird issue with the refactored ajax call and the new env.sh in the terminal, but once that was resolved it was pretty straightforward to create and set the env variable. I deployed this branch to heroku you can see it here: https://mike-mailman-portfolio.herokuapp.com/
